### PR TITLE
Improve Layout of Cuisines Filter Tabs in Enatega Main App (#468)

### DIFF
--- a/enatega-multivendor-app/src/components/Filter/FilterSlider.js
+++ b/enatega-multivendor-app/src/components/Filter/FilterSlider.js
@@ -60,11 +60,8 @@ const Filters = ({ filters, setFilters, applyFilters }) => {
   }
 
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={styles(currentTheme).container}
-    >
+    <View style={styles(currentTheme).container}>
+
       <TouchableOpacity
         style={styles(currentTheme).filterButton}
         onPress={handleOptionsClick}
@@ -169,7 +166,7 @@ const Filters = ({ filters, setFilters, applyFilters }) => {
           </TouchableOpacity>
         </ScrollView>
       </Modal>
-    </ScrollView>
+    </View>
   )
 }
 

--- a/enatega-multivendor-app/src/components/Filter/styles.js
+++ b/enatega-multivendor-app/src/components/Filter/styles.js
@@ -5,10 +5,13 @@ const styles = (props = null) =>
   StyleSheet.create({
     container: {
       flexDirection: 'row',
+      flexWrap: 'wrap', // allow it to wrap to next line
+      justifyContent: 'space-between',
       alignItems: 'center',
-      backgroundColor: props !== null ? props.themeBackground : '#fff',
+      gap: scale(8),
       padding: scale(10),
-      marginBottom: scale(10)
+      marginBottom: scale(10),
+      backgroundColor: props?.themeBackground || '#fff'
     },
     filterButton: {
       paddingHorizontal: 15,


### PR DESCRIPTION
### What I Changed

- Replaced horizontal ScrollView with a wrapping View in `Filters.js`
- Updated container style to use `flexWrap: 'wrap'` and `justifyContent: 'space-between'`
- Ensured cuisine filter tabs now stay within 2 lines by filling the second line's empty space

### Why It Matters

This fixes UI clutter by optimizing layout space. On smaller screens, filters were wrapping to a third line even when space was available on the second. This change keeps the filter section visually clean and compact.

Fixes #468 ✅
